### PR TITLE
Refactor transaction notification logic 

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -37,8 +37,6 @@ def create_app():
     from .api import metrics_blueprint
     app.register_blueprint(metrics_blueprint)
 
-    from .tasks import walletnotify_shkeeper
-
     db.init_app(app)
     with app.app_context():
 

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -55,20 +55,6 @@ def post_payout_results(data, symbol):
 
 
 @celery.task()
-def walletnotify_shkeeper(symbol, txid):
-    while True:
-        try:
-            r = rq.post(
-                    f'http://{config["SHKEEPER_HOST"]}/api/v1/walletnotify/{symbol}/{txid}',
-                    headers={'X-Shkeeper-Backend-Key': config['SHKEEPER_KEY']}
-                )
-            return r
-        except Exception as e:
-            logger.warning(f'Shkeeper notification failed for {symbol}/{txid}: {e}')
-            time.sleep(10)
-
-
-@celery.task()
 def refresh_balances():
     updated = 0
 


### PR DESCRIPTION
Refactor transaction notification logic  to prevent missed events

Move payment notification logic to block scanner module and wait for shkeeper confirmation before scanning further blocks to  prevent missed notifications about transactions